### PR TITLE
minor death tracer changes

### DIFF
--- a/src/client/render/core.cpp
+++ b/src/client/render/core.cpp
@@ -91,6 +91,7 @@ void RenderingCore::draw(video::SColor _skycolor, bool _show_hud, bool _show_min
 	entity_esp_color = video::SColor(255, entity_color.X, entity_color.Y, entity_color.Z);
 	player_esp_color = video::SColor(255, player_color.X, player_color.Y, player_color.Z);
 	death_tracer_color = video::SColor(255,255,255,255);
+	death_box_color = video::SColor(255,237,2,2);
 	
 
 	if (shadow_renderer) {
@@ -177,7 +178,7 @@ void RenderingCore::drawTracersAndESP()
 		box.MinEdge += dpos;
 		box.MaxEdge += dpos;
 		driver->draw3DLine(eye_pos,box.getCenter(),death_tracer_color);
-		driver->draw3DBox(box,death_tracer_color);
+		driver->draw3DBox(box,death_box_color);
 	}
 
 	driver->setMaterial(oldmaterial);

--- a/src/client/render/core.h
+++ b/src/client/render/core.h
@@ -51,6 +51,7 @@ protected:
 	video::SColor entity_esp_color;
 	video::SColor player_esp_color;
 	video::SColor death_tracer_color;
+	video::SColor death_box_color;
 
 	IrrlichtDevice *device;
 	video::IVideoDriver *driver;

--- a/src/network/connection.cpp
+++ b/src/network/connection.cpp
@@ -33,6 +33,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "util/string.h"
 #include "settings.h"
 #include "profiler.h"
+#include "client/render/core.h"
 
 namespace con
 {
@@ -538,11 +539,13 @@ ConnectionCommandPtr ConnectionCommand::connect(Address address)
 
 ConnectionCommandPtr ConnectionCommand::disconnect()
 {
+	died = false;
 	return create(CONNCMD_DISCONNECT);
 }
 
 ConnectionCommandPtr ConnectionCommand::disconnect_peer(session_t peer_id)
 {
+	died = false;
 	auto c = create(CONNCMD_DISCONNECT_PEER);
 	c->peer_id = peer_id;
 	return c;
@@ -1415,6 +1418,7 @@ bool Connection::Connected()
 
 void Connection::Disconnect()
 {
+	died = false;
 	putCommand(ConnectionCommand::disconnect());
 }
 


### PR DESCRIPTION
This PR changes the following aspects about the death tracer:

- the box is now red, while the line remained blue, making it easier to see where it ends
- upon disconnecting, the tracer disappears, the value is still stored until it's being overwritten though

**TEST BEFORE MERGING, GITHUB'S CMAKE ISN'T CONFIGURED CORRECTLY**